### PR TITLE
On execution, reset timer _before_ firing callback

### DIFF
--- a/lib/workers/scheduler.rb
+++ b/lib/workers/scheduler.rb
@@ -76,11 +76,12 @@ module Workers
       end
 
       overdue.each do |timer|
+        timer.reset
+
         @pool.perform do
           timer.fire
         end
 
-        timer.reset
         @schedule << timer if timer.repeat
       end
 


### PR DESCRIPTION
Prevents an edge case where a context switch between firing of the callback and timer reset caused nested timers (timer that is launched within another timer callback) to deadlock.

See issue #9 