### PR TITLE
Stop using a red black tree for the scheduler (SortedSet)

### DIFF
--- a/lib/workers.rb
+++ b/lib/workers.rb
@@ -2,6 +2,7 @@ require 'thread'
 require 'monitor'
 require 'set'
 
+require 'workers/sorted_set'
 require 'workers/version'
 require 'workers/exceptions'
 require 'workers/helpers'

--- a/lib/workers/sorted_set.rb
+++ b/lib/workers/sorted_set.rb
@@ -1,0 +1,131 @@
+#
+# SortedSet implements a Set that guarantees that its elements are
+# yielded in sorted order (according to the return values of their
+# #<=> methods) when iterating over them.
+#
+# All elements that are added to a SortedSet must respond to the <=>
+# method for comparison.
+#
+# Also, all elements must be <em>mutually comparable</em>: <tt>el1 <=>
+# el2</tt> must not return <tt>nil</tt> for any elements <tt>el1</tt>
+# and <tt>el2</tt>, else an ArgumentError will be raised when
+# iterating over the SortedSet.
+#
+# == Example
+#
+#   require "set"
+#
+#   set = SortedSet.new([2, 1, 5, 6, 4, 5, 3, 3, 3])
+#   ary = []
+#
+#   set.each do |obj|
+#     ary << obj
+#   end
+#
+#   p ary # => [1, 2, 3, 4, 5, 6]
+#
+#   set2 = SortedSet.new([1, 2, "3"])
+#   set2.each { |obj| } # => raises ArgumentError: comparison of Fixnum with String failed
+#
+module Workers
+  class SortedSet < Set
+    @@setup = false
+    @@mutex = Mutex.new
+
+    class << self
+      def [](*ary)        # :nodoc:
+        new(ary)
+      end
+
+      def setup   # :nodoc:
+        @@setup and return
+
+        @@mutex.synchronize do
+          # a hack to shut up warning
+          alias_method :old_init, :initialize
+
+          def initialize(*args)
+            @keys = nil
+            super
+          end
+
+          def clear
+            @keys = nil
+            super
+          end
+
+          def replace(enum)
+            @keys = nil
+            super
+          end
+
+          def add(o)
+            o.respond_to?(:<=>) or raise ArgumentError, "value must respond to <=>"
+            @keys = nil
+            super
+          end
+          alias << add
+
+          def delete(o)
+            @keys = nil
+            @hash.delete(o)
+            self
+          end
+
+          def delete_if
+            block_given? or return enum_for(__method__) { size }
+            n = @hash.size
+            super
+            @keys = nil if @hash.size != n
+            self
+          end
+
+          def keep_if
+            block_given? or return enum_for(__method__) { size }
+            n = @hash.size
+            super
+            @keys = nil if @hash.size != n
+            self
+          end
+
+          def merge(enum)
+            @keys = nil
+            super
+          end
+
+          def each(&block)
+            block or return enum_for(__method__) { size }
+            to_a.each(&block)
+            self
+          end
+
+          def to_a
+            (@keys = @hash.keys).sort! unless @keys
+            @keys.dup
+          end
+
+          def freeze
+            to_a
+            super
+          end
+
+          def rehash
+            @keys = nil
+            super
+          end
+
+          # a hack to shut up warning
+          remove_method :old_init
+
+          @@setup = true
+        end
+      end
+    end
+
+    def initialize(*args, &block) # :nodoc:
+      SortedSet.setup
+      @keys = nil
+      super
+    end
+  end
+end


### PR DESCRIPTION
The existing implementation of `SortedSet` (ruby 2 and 3) asks each new timer to compare to other timers at the time of insertion and then places the object in the tree so it is sorted. Well, this gem is calculating the time remaining for a timer, but it never recalculates after the value is inserted into the tree.

This implementation evaluates `sec_remaining` when it accesses the set, which is required because the order is determined by that value, which changes over time. The previous implementation was not reevaluating these on insert, so the order would become more wrong over time.

The implementation of SortedSet is the ruby version from 2.x which was removed [here](https://github.com/ruby/set/pull/2). For large data sets it is definitely inefficient, but it is functional.